### PR TITLE
added dotenv to manage environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ yarn-debug.log*
 
 # file containing google oauth env key
 /config/environments/development.rb
+
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,9 @@ group :development, :test do
   gem 'rubocop-performance'
   gem 'rubocop-rails'
   gem 'rubocop-rspec'
+
+  # manage environment variables
+  gem 'dotenv-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,10 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.4.4)
     docile (1.4.0)
+    dotenv (2.7.6)
+    dotenv-rails (2.7.6)
+      dotenv (= 2.7.6)
+      railties (>= 3.2)
     erubi (1.10.0)
     execjs (2.8.1)
     faraday (1.8.0)
@@ -334,6 +338,7 @@ DEPENDENCIES
   byebug
   capybara (>= 3.26)
   devise
+  dotenv-rails
   jbuilder (~> 2.7)
   jquery-rails
   listen (~> 3.3)

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,9 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+# laod .env to get environment variables
+Dotenv::Railtie.load
+
 module InfoTracker
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.


### PR DESCRIPTION
added dotenv gem
added .env file and put in google oauth & config keys in there (config keys not needed but just in case)
load .env in config/application.rb so app can read environment variables
added .env to .gitignore file to not push it up to github