### PR TITLE
took out initialization of Dotenv in config/application.rb

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,9 +8,6 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-# laod .env to get environment variables
-Dotenv::Railtie.load
-
 module InfoTracker
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.


### PR DESCRIPTION
had to take out manual initialization of Dotenv in this file b/c the Dotenv
gem is only installed in development & test so Dotenv can't be initialized
in production (on Heroku), leading to a there a compilation error when running rake.
Also, Dotenv runs automatically during 'before_configuration' callback during
the initialization of Applicaion defined in config/application.rb and there
isn't a need to do initialize Dotenv beforehand.
https://www.rubydoc.info/gems/dotenv-rails/2.1.1